### PR TITLE
Improve naming of old releases path with customizable defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ require 'capistrano/lazy_cleanup'
 Capistrano::LazyCleanup can be used out of the box, but you can further customize the configuration at your `deploy.rb`.
 
 ```ruby
-# Defaults to "#{fetch(:tmp_dir, '/tmp')}/capistrano-lazy_cleanup_old_releases.XXXXXXXXXX"
+# Defaults to "#{fetch(:tmp_dir)}/cap-lazy-cleanup-#{fetch(:application)}.XXXXXXXXXX"
 set :lazy_cleanup_old_releases_path_template, "/tmp/my-old-releases.XXXXXXXXXX"
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,11 +21,26 @@ Or install it yourself as:
 
 ## Usage
 
+Capfile
+
 ```ruby
-require 'capistrano/deploy' # This should be required in advance
+# Load DSL and set up stages
+require "capistrano/setup"
+
+# Include default deployment tasks
+require "capistrano/deploy" # This should be required in advance
 
 # Capfile
 require 'capistrano/lazy_cleanup'
+```
+
+## Configuration
+
+Capistrano::LazyCleanup can be used out of the box, but you can further customize the configuration at your `deploy.rb`.
+
+```ruby
+# Defaults to "#{fetch(:tmp_dir, '/tmp')}/capistrano-lazy_cleanup_old_releases.XXXXXXXXXX"
+set :lazy_cleanup_old_releases_path_template, "/tmp/my-old-releases.XXXXXXXXXX"
 ```
 
 ## What exactly does the `offloading` mean?

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ On heavy application, it takes time to execute `deploy:cleanup` and `deploy:clea
 
 This gem replaces `rm -rf` with `mktemp` and `mv`. The old release paths are moved to temporary directory. Capistrano and the kernel should handle only the top directory on deployment. After the deployment, files in temporary directory will be eventually cleaned up by low-priorty processes provided by OS.
 
+## Caveats
+
+This gem heavily uses `fetch(:tmp_dir)` as the temporary directory. Therefore, when the combination of deployment size and frequency overwhelms cleanup cycle of your OS, you might encounter disk full issue. You can mitigate this by specifying additional fast cleanup rule on `lazy_cleanup_old_releases_path_template`. (e.g. `tmpwatch -umc 1 /tmp/cap-lazy-cleanup*`)
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/capistrano/lazy_cleanup.rb
+++ b/lib/capistrano/lazy_cleanup.rb
@@ -1,4 +1,5 @@
 require "capistrano/lazy_cleanup/version"
+require "capistrano/lazy_cleanup/defaults"
 
 module Capistrano
   module LazyCleanup

--- a/lib/capistrano/lazy_cleanup/defaults.rb
+++ b/lib/capistrano/lazy_cleanup/defaults.rb
@@ -10,5 +10,5 @@ end
 # TODO: If Capistrano::Plugin system becomes stable, refactor these code.
 
 Rake::Task.define_task('load:defaults') do
-  set_if_empty(:lazy_cleanup_old_releases_path_template, "#{fetch(:tmp_dir, '/tmp')}/capistrano-lazy_cleanup_old_releases.XXXXXXXXXX")
+  set_if_empty :lazy_cleanup_old_releases_path_template, -> { "#{fetch(:tmp_dir)}/cap-lazy-cleanup-#{fetch(:application)}.XXXXXXXXXX" }
 end

--- a/lib/capistrano/lazy_cleanup/defaults.rb
+++ b/lib/capistrano/lazy_cleanup/defaults.rb
@@ -1,0 +1,14 @@
+require 'rake'
+
+module Capistrano
+  module LazyCleanup
+    module Defaults
+    end
+  end
+end
+
+# TODO: If Capistrano::Plugin system becomes stable, refactor these code.
+
+Rake::Task.define_task('load:defaults') do
+  set_if_empty(:lazy_cleanup_old_releases_path_template, "#{fetch(:tmp_dir, '/tmp')}/capistrano-lazy_cleanup_old_releases.XXXXXXXXXX")
+end

--- a/lib/capistrano/tasks/lazy_cleanup.rake
+++ b/lib/capistrano/tasks/lazy_cleanup.rake
@@ -24,7 +24,7 @@ namespace :capistrano do
             debug t(:no_current_release, host: host.to_s)
           end
           if directories.any?
-            temp_dir = capture(:mktemp, '-d')
+            temp_dir = capture(:mktemp, '-d', fetch(:lazy_cleanup_old_releases_path_template))
             execute :mv, *directories, temp_dir
           else
             info t(:no_old_releases, host: host.to_s, keep_releases: fetch(:keep_releases))
@@ -42,7 +42,7 @@ namespace :capistrano do
           execute :tar, "-czf",
                   deploy_path.join("rolled-back-release-#{last_release}.tar.gz"),
                   last_release_path
-          temp_dir = capture(:mktemp, '-d')
+          temp_dir = capture(:mktemp, '-d', fetch(:lazy_cleanup_old_releases_path_template))
           execute :mv, last_release_path, temp_dir
         else
           debug "Last release is the current release, skip cleanup_rollback."


### PR DESCRIPTION
## Background

Previously, old releases path of `Capistrano::LazyCleanup` is the result of `mktemp -d`.
This is simple and secure way to make temporary directory.

The problem is that the result path is difficult to search.
Especially, in the environment with limited disk resource and frequent deployments, additional cleanup process might be required (e.g. `tmpwatch`). Simple random directory paths prevent developers make efficient and simple rule for this additional cleanup.

## Solution

* Use `fetch(:tmp_dir)` as the base path for temporary directory.
  * This is supported by Capistrano, and useful for `mktemp` portability issue.
  * https://github.com/capistrano/capistrano/blob/v3.11.0/lib/capistrano/defaults.rb#L26
* Insert `capistrano-lazy_cleanup` into the default template
  * Developers can easily find the old releases path.
* Let developers set `lazy_cleanup_old_releases_path_template`
  * Developers can further customize the path for old releases.